### PR TITLE
Add Claude Code web session start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote environments (Claude Code on the web)
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+echo "Installing dependencies for Quoncierge development..."
+
+# Install ShellCheck for bash script linting
+# Using apt-get since this runs in a Debian/Ubuntu-based container
+if ! command -v shellcheck &> /dev/null; then
+  echo "Installing ShellCheck..."
+  apt-get install -y -qq shellcheck > /dev/null 2>&1
+  echo "✓ ShellCheck installed"
+else
+  echo "✓ ShellCheck already installed"
+fi
+
+echo "Dependencies installed successfully!"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Configure SessionStart hook to install ShellCheck for bash script linting.
This enables automated linting and syntax checking in Claude Code web sessions.

- Created .claude/hooks/session-start.sh to install ShellCheck
- Registered hook in .claude/settings.json
- Hook only runs in remote environments (Claude Code web)
- Validated hook execution, linting, and syntax checking